### PR TITLE
validate the commstemplate classification against the classificationtype table

### DIFF
--- a/application/models/classification_type.py
+++ b/application/models/classification_type.py
@@ -7,6 +7,4 @@ class ClassificationType(db.Model):
     name = db.Column(db.Text, unique=True, primary_key=True)
 
     def to_dict(self):
-        return {
-            "name": self.name
-        }
+        return self.name

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -10,16 +10,6 @@ class CommunicationType(IntEnum):
     SMS = 2
 
 
-class ClassificationType(IntEnum):
-    LEGAL_STATUS = 0
-    INDUSTRY = 1
-    GEOGRAPHY = 2
-    COLLECTION_EXERCISE = 3
-    RU_REF = 4
-    SURVEY_REF = 5
-    ENROLMENT_STATUS = 6
-
-
 class CommunicationTemplate(db.Model):
     __tablename__ = 'template'
 
@@ -29,7 +19,6 @@ class CommunicationTemplate(db.Model):
     uri = db.Column(db.Text)
     classification = db.Column(JSONB)
     params = db.Column(JSONB)
-    schema = "templatesvc"
 
     def to_dict(self):
         return {

--- a/run.py
+++ b/run.py
@@ -11,7 +11,7 @@ def create_app(config_path):
     app = Flask(__name__)
     app.config.from_object(config_path)
 
-    from application.models.models import CommunicationTemplate, ClassificationType, CommunicationType # NOQA  # pylint: disable=wrong-import-position
+    from application.models.models import CommunicationTemplate, CommunicationType # NOQA  # pylint: disable=wrong-import-position
     from application.models.classification_type import ClassificationType # NOQA  # pylint: disable=wrong-import-position
 
     # Set up database

--- a/tests/controllers/test_template_controller.py
+++ b/tests/controllers/test_template_controller.py
@@ -1,11 +1,13 @@
 from application.controllers import template_controller
 from application.utils.exceptions import InvalidTemplateException
 from tests.test_client import TestClient
+from unittest import mock
 
 
 class TestTemplateController(TestClient):
 
-    def test_create_existing_template_raises_invalid_template_exception(self):
+    @mock.patch('application.controllers.template_controller.get_classification_types', return_value=["GEOGRAPHY"])
+    def test_create_existing_template_raises_invalid_template_exception(self, get_classification_types):
         template_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef91"
         template_object = dict(id="cb0711c3-0ac8-41d3-ae0e-567e5ea1ef91", label="test data", type="EMAIL",
                                uri="test-uri.com", classification={"GEOGRAPHY": "NI"})
@@ -36,7 +38,9 @@ class TestTemplateController(TestClient):
 
         self.assertEquals(template, None)
 
-    def test_get_template_by_classifiers(self):
+    @mock.patch('application.controllers.template_controller.get_classification_types',
+                return_value=["GEOGRAPHY", "INDUSTRY"])
+    def test_get_template_by_classifiers(self, get_classification_types):
         # given the template exists in the database
         template_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef91"
         classifiers = {"GEOGRAPHY": "NI",
@@ -62,7 +66,8 @@ class TestTemplateController(TestClient):
 
         self.assertEquals(template_list, None)
 
-    def test_delete_template(self):
+    @mock.patch('application.controllers.template_controller.get_classification_types', return_value=["GEOGRAPHY"])
+    def test_delete_template(self, get_classification_types):
         # Given the template exists in the database
         template_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef91"
         template_object = dict(id="cb0711c3-0ac8-41d3-ae0e-567e5ea1ef91", label="test data", type="EMAIL",

--- a/tests/views/test_classification_type_view.py
+++ b/tests/views/test_classification_type_view.py
@@ -36,8 +36,7 @@ class TestClassificationTypeView(TestClient):
 
         # Then the service returns the classification types
         self.assertStatus(response, 200)
-        expected_response = [{"name": "LEGAL_BASIS"}, {"name": "GEOGRAPHY"}]
-        self.assertEquals(response.json, expected_response)
+        self.assertEquals(response.json, ["LEGAL_BASIS", "GEOGRAPHY"])
 
     def test_get_classification_types_if_none_in_db(self):
         # Given there are no classification types in the database
@@ -55,9 +54,8 @@ class TestClassificationTypeView(TestClient):
         response = self.client.get("/classificationtype/{}".format(classification_type))
 
         # Then the service returns the classfication type
-        expected_response = {"name": classification_type}
         self.assertStatus(response, 200)
-        self.assertEquals(response.json, expected_response)
+        self.assertEquals(response.json, classification_type)
 
     def test_get_non_existent_classification_type(self):
         # Given the classification type doesn't exist

--- a/tests/views/test_sessions.py
+++ b/tests/views/test_sessions.py
@@ -8,7 +8,14 @@ class TestSessions(TestClient):
     """ This test class is to check that the inbuilt flask and flask-sqlalchemy session management is working
     I.e does it rollback sessions on exception, is it committed """
 
+    def _create_classification_type(self, classification_type):
+        response = self.client.post('/classificationtype/{}'.format(classification_type))
+        self.assertStatus(response, 201)
+
     def test_rollback_on_exception(self):
+        # Given there are classification types
+        self._create_classification_type("GEOGRAPHY")
+
         # When an invalid comms template is uploaded
         data = dict(label="test data")
         template_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef99"
@@ -23,6 +30,9 @@ class TestSessions(TestClient):
         self.assertEquals(template, None)
 
     def test_commit_on_successful_request(self):
+        # Given there are classification types
+        self._create_classification_type("GEOGRAPHY")
+
         # When a valid comms template is uploaded
         template_id = "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef99"
         data = dict(id=template_id, label="test data", type="EMAIL", uri="test-uri.com",


### PR DESCRIPTION
Speaking to @JamesGardiner about the mocking. Not sure whether it reduces readability or improves.

Setting up the test data for the template unit tests now involves
- create classification type
- create comms template (which is validated  against that classification type)

DO TEST