### PR TITLE
use a regex "rds*" to find the rds vcap configurations

### DIFF
--- a/application/cloud/cloudfoundry.py
+++ b/application/cloud/cloudfoundry.py
@@ -1,4 +1,5 @@
 import cfenv
+import re
 
 
 class ONSCloudFoundry(object):
@@ -12,4 +13,4 @@ class ONSCloudFoundry(object):
 
     @property
     def db(self):
-        return self._cf_env.get_service(label='rds')
+        return self._cf_env.get_service(label=re.compile(r'rds*'))


### PR DESCRIPTION
make the rds vcap config discovery flexible by using the regex "rds*", this fits the pattern throughout the environments